### PR TITLE
Let dsyevr determine the number of output analyses

### DIFF
--- a/src/enkf/letkf.f90
+++ b/src/enkf/letkf.f90
@@ -703,6 +703,7 @@ subroutine letkf_core(nobsl,hxens,hxens_orig,dep,&
 
 implicit none
 integer(i_kind), intent(in) :: nobsl,nanals,neigv
+integer(i_kind) :: o_nanals
 real(r_kind),dimension(nobsl),intent(in ) :: rdiaginv,rloc
 real(r_kind),dimension(nanals,nobsl),intent(inout)  :: hxens
 real(r_single),dimension(nanals/neigv,nobsl),intent(in)  :: hxens_orig
@@ -732,9 +733,9 @@ endif
 allocate(work3(nanals,nanals),evecs(nanals,nanals))
 allocate(rrloc(nobsl),gammapI(nanals),evals(nanals),gamma_inv(nanals))
 ! for dsyevr
-!!allocate(iwork(10*nanals),work1(70*nanals))
+allocate(iwork(10*nanals),work1(70*nanals))
 ! for dsyevd
-allocate(iwork(3+5*nanals),work1(1+6*nanals+2*nanals*nanals))
+!allocate(iwork(3+5*nanals),work1(1+6*nanals+2*nanals*nanals))
 
 ! HZ^T = hxens sqrt(Rinv)
 rrloc = rdiaginv * rloc
@@ -757,11 +758,11 @@ if(r_kind == kind(1.d0)) then ! double precision
                hxens,nanals,0.d0,work3,nanals)
    ! evecs contains eigenvectors of HZ^T HZ, or left singular vectors of HZ
    ! evals contains eigenvalues (singular values squared)
-!!   call dsyevr('V','A','L',nanals,work3,nanals,vl,vu,1,nanals,-1.d0,nanals,evals,evecs, &
-!!               nanals,isuppz,work1,lwork,iwork,liwork,ierr)
+   call dsyevr('V','A','L',nanals,work3,nanals,vl,vu,1,nanals,-1.d0,o_nanals,evals,evecs, &
+               nanals,isuppz,work1,lwork,iwork,liwork,ierr)
 ! use LAPACK dsyevd instead of dsyevr
-   evecs = work3
-   call dsyevd('V','L',nanals,evecs,nanals,evals,work1,lwork,iwork,liwork,ierr)
+!!   evecs = work3
+!!   call dsyevd('V','L',nanals,evecs,nanals,evals,work1,lwork,iwork,liwork,ierr)
 else ! single precision
    call sgemm('n','t',nanals,nanals,nobsl,1.e0,hxens,nanals, &
                hxens,nanals,0.e0,work3,nanals)


### PR DESCRIPTION
**Description**

This lets the `dsyevr` subroutine determine the number of output analyses (i.e. the number of returned eigenvalues/eigenvectors).

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update